### PR TITLE
train of pairs: Use block-wise terminology

### DIFF
--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -243,7 +243,7 @@ DNS Responses in CoAP Responses
 Each DNS query-response pair is mapped to a CoAP REST request-response
 operation, which may consist of several CoAP request-response pairs if
 block-wise transfer is involved.  DNS responses are provided in the body (i.e. the
-payload, or the concatenated payloads) of CoAP response. A DoC server MUST
+payload, or the concatenated payloads) of the CoAP response. A DoC server MUST
 indicate the type of content of the body using the Content-Format option. This
 document specifies the usage of Content-Format "application/dns-message"
 (details see {{sec:content-format}}).

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -240,11 +240,13 @@ FETCH request:
 DNS Responses in CoAP Responses
 -------------------------------
 
-Each DNS query-response pair is mapped to a train of one or more of CoAP
-request-response pairs.  DNS responses are provided in the payload of CoAP
-responses. A DoC server MUST indicate the type of content of the payload using
-the Content-Format option. This document specifies the usage of Content-Format
-"application/dns-message" (details see {{sec:content-format}}).
+Each DNS query-response pair is mapped to a CoAP REST request-response
+operation, which may consist of several CoAP request-response pairs if
+block-wise transfer is involved.  DNS responses are provided in the body (i.e. the
+payload, or the concatenated payloads) of CoAP response. A DoC server MUST
+indicate the type of content of the body using the Content-Format option. This
+document specifies the usage of Content-Format "application/dns-message"
+(details see {{sec:content-format}}).
 
 If supported, a DoC server MAY transfer the DNS response in more than one
 CoAP responses using the Block2 option {{!RFC7959}}.


### PR DESCRIPTION
"body" and "payload" are distinguished there, as are "operation" and
"exchange"; both explained here briefly.

(As much as I like the train metaphor, there *is* already terminology.)