### PR TITLE
Caching: move bulk of Max-Age / TTL calculation part to DoC server

### DIFF
--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -267,31 +267,6 @@ The DoC server SHOULD send compact answers, i.e., additional or authority sectio
 response should only be sent if needed or if it is anticipated that they help the DoC client to
 reduce additional queries.
 
-Proxies and caching
--------------------
-
-TBD:
-
-- Responses that are not globally valid
-- General CoAP proxy problem, but what to do when DoC server is a DNS proxy,
-  response came not yet in but retransmission by DoC client was received (see
-  {{rt-problem}})
-    - send empty ACK ([maybe move to best practices appendix](https://github.com/anr-bmbf-pivot/draft-dns-over-coap/issues/6#issuecomment-895880206))
-
-      ~~~ drawing
-      DoC client           DoC proxy           DNS server
-           |  CoAP req [rt 1]  |                    |
-           |------------------>|  DNS query [rt 1]  |
-           |                   |------------------->|
-           |  CoAP req [rt 2]  |                    |
-           |------------------>|      DNS resp      |
-           |     CoAP resp     |<-------------------|
-           |<------------------|                    |
-           |                   |                    |
-      ~~~
-      {: #rt-problem title="CoAP retransmission (rt) is received before DNS query could have been
-      fulfilled."}
-
 Observing the DNS Resource
 --------------------------
 There are use cases where updating a DNS record might be necessary on the fly.

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -203,10 +203,17 @@ The DoC client might also decide to repeat a non-successful exchange with a diff
 
 ### Support of CoAP Caching {#sec:resp-caching}
 
-It is RECOMMENDED to set the Max-Age option of a response to the minimum TTL in the Answer section of a DNS response. This prevents expired records unintentionally being served from a CoAP cache.
+The DoC server MUST ensure that any sum of the Max-Age value of a CoAP response and any TTL in the
+DNS response is less or equal to the corresponding TTL received from an upstream DNS server.
+This also includes the default Max-Age value of 60 seconds (see {{!RFC7252}}, section 5.10.5) when no Max-Age option is provided.
+The DoC client MUST then add the Max-Age value of the carrying CoAP response to all TTLs in a DNS response on reception and use these calculated TTLs for the associated records.
 
-<!-- It is RECOMMENDED that DoC servers set an ETag option on large responses (TBD: more concrete guidance) that have a short Max-Age relative to the expected clients' caching time.
-Thus, clients that need to revalidate a response can do so using the established ETag mechanism.
+The RECOMMENDED algorithm to assure the requirement for the DoC is to set the Max-Age option of a response to the minimum TTL of a DNS response and to subtract this value from all TTLs of that DNS response.
+This prevents expired records unintentionally being served from an intermediate CoAP cache.
+Additionally, it allows for the ETag value to not change if it is based on the content and the TTL values are updated by an upstream DNS cache.
+
+
+<!--
 With short responses, a usable ETag might be almost as long as the response.
 With long-lived responses, the client does not need to revalidate often.
 With responses large enough to be fragmented,
@@ -264,7 +271,6 @@ Proxies and caching
 
 TBD:
 
-- [TTL vs. Max-Age](https://github.com/anr-bmbf-pivot/draft-dns-over-coap/issues/5)
 - Responses that are not globally valid
 - General CoAP proxy problem, but what to do when DoC server is a DNS proxy,
   response came not yet in but retransmission by DoC client was received (see

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -210,7 +210,8 @@ The DoC client MUST then add the Max-Age value of the carrying CoAP response to 
 
 The RECOMMENDED algorithm to assure the requirement for the DoC is to set the Max-Age option of a response to the minimum TTL of a DNS response and to subtract this value from all TTLs of that DNS response.
 This prevents expired records unintentionally being served from an intermediate CoAP cache.
-Additionally, it allows for the ETag value to not change if it is based on the content and the TTL values are updated by an upstream DNS cache.
+Additionally, it allows for the ETag value for cache validation, if it is based on the content of the response, not to change even if the TTL values are updated by an upstream DNS cache.
+If only one record set per DNS response is assumed, a simplification of this algorithm is to just set all TTLs in the response to 0 and set the TTLs at the DoC client to the value of the Max-Age option.
 
 
 <!--


### PR DESCRIPTION
This offers an alternative to https://github.com/anr-bmbf-pivot/draft-dns-over-coap/pull/17 in response to https://github.com/anr-bmbf-pivot/draft-dns-over-coap/pull/17#issuecomment-1059931619.

Now, instead of using the minimum TTL as Max-Age at the DoC server and then the DoC client needing to calculate the "true TTL" after caching from the Max-Age, the bulk of checking and calculating now happens at the (presumed to be more powerful) DoC server: The DoC server takes the mimimum TTL and substracts it from all TTLs in the DNS response, the DoC client then only takes the Max-Age and adds it to all TTLs again (instead of needing to search the minimum TTL first, calculating the difference and then adding it to all TTLs).

For illustration, here the example @chrysn gave me offline:

Let's assume there is an upstream DNS server, a DoC server that serves responses from that DNS server and also has its own DNS cache, and a (DoC agnostic) CoAP proxy between the DoC server and one or more DoC clients. A DoC client requests a an A record for `example.org` and it leads to the following situation.

- Upstream DNS sent: `example.org` TTL=300 IN A 192.0.2.7
- DNS cache at DoC server, however, had that response already for 100s and sends: `example.org` TTL=200 IN A 192.0.2.7
- DoC server, as such, sends: Max-Age=200, E-Tag=_h_, 2.05 Content, [`example.org` TTL=0 IN A 192.0.2.7]
   - _h_ is a hash over the response payload [`example.org` TTL=0 IN A 192.0.2.7]
- The CoAP proxy, as such, receives that and caches for 200s in a manner where it is only deleted when a cache out is happening and otherwise just marked stale

20 minutes later, the CoAP proxy receives yet another request for an A record for `example.org`, the response is in the cache, but marked stale. As such, it asks the DoC server for revalidation using by sending the E-Tag `h`. The DoC server does not have the response in its DNS cache anymore and thus asks upstream:

- Upstream DNS still sends: `example.org` TTL=300 IN A 192.0.2.7
- DoC server receives that and prepares:  Max-Age=300, E-Tag=_h_, 2.05 Content [`example.org` TTL=0 IN A 192.0.2.7]
- Since _h_ still is the same, it can just send: Max-Age=300, E-Tag=_h_, 2.03 Valid
- The CoAP proxy receives that response and just need to un-stale the cache entry (unless it was, of course, cached out in the meantime, in which case it should re-request without E-Tag).

### TODO: Adapt examples!