### PR TITLE
Add some message manipulation considerations for DoC servers (No. 2)

### DIFF
--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -267,7 +267,7 @@ CoAP/CoRE Integration
 
 DoC server considerations
 -------------------------
-In the case of CNAME records n a DNS response, a DoC server SHOULD follow common DNS resolver
+In the case of CNAME records in a DNS response, a DoC server SHOULD follow common DNS resolver
 behavior {{?RFC1034}} by resolving a CNAME until the originally requested resource record type is
 reached. This reduces the number of message exchanges within an LLN.
 

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -265,6 +265,17 @@ the server.
 CoAP/CoRE Integration
 =====================
 
+DoC server considerations
+-------------------------
+To reduce the number of message exchanges within an LLN, a DoC server MAY try
+to resolve CNAME chains received in DNS responses from an upstream DNS resolver.
+
+If not explicitly requested in the DNS query, it is RECOMMENDED to strip all record entries of type
+NS and class IN and all associated A and AAAA records from DNS responses received from upstream DNS
+resolvers.
+The NS record can not be used effectively by DoC anyway and tend to increase DNS response sizes
+unnecessarily.
+
 Proxies and caching
 -------------------
 

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -271,9 +271,9 @@ In the case of CNAME records in a DNS response, a DoC server SHOULD follow commo
 behavior {{?RFC1034}} by resolving a CNAME until the originally requested resource record type is
 reached. This reduces the number of message exchanges within an LLN.
 
-The DoC server SHOULD send compact answers, i.e., add additional or authority sections in the DNS
-reply should only be sent if needed or anticipated that they help the DoC client to reduce
-additional queries. Any excessive information MAY be stripped from the DNS response.
+The DoC server SHOULD send compact answers, i.e., additional or authority sections in the DNS
+response should only be sent if needed or if it is anticipated that they help the DoC client to
+reduce additional queries. Any excessive information MAY be stripped from the DNS response.
 
 Proxies and caching
 -------------------

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -271,11 +271,9 @@ In the case of CNAME records in a DNS response, a DoC server SHOULD follow commo
 behavior {{?RFC1034}} by resolving a CNAME until the originally requested resource record type is
 reached. This reduces the number of message exchanges within an LLN.
 
-If not explicitly requested in the DNS query, it is RECOMMENDED to strip all record entries of type
-NS and class IN and all associated A and AAAA records from DNS responses received from upstream DNS
-resolvers.
-The NS record can not be used effectively by DoC anyway and tend to increase DNS response sizes
-unnecessarily.
+The DoC server SHOULD send compact answers, i.e., add additional or authority sections in the DNS
+reply should only be sent if needed or anticipated that they help the DoC client to reduce
+additional queries. Any additional information MAY be stripped from the DNS response.
 
 Proxies and caching
 -------------------

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -273,7 +273,7 @@ reached. This reduces the number of message exchanges within an LLN.
 
 The DoC server SHOULD send compact answers, i.e., additional or authority sections in the DNS
 response should only be sent if needed or if it is anticipated that they help the DoC client to
-reduce additional queries. Any excessive information MAY be stripped from the DNS response.
+reduce additional queries.
 
 Proxies and caching
 -------------------

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -267,8 +267,9 @@ CoAP/CoRE Integration
 
 DoC server considerations
 -------------------------
-To reduce the number of message exchanges within an LLN, a DoC server MAY try
-to resolve CNAME chains received in DNS responses from an upstream DNS resolver.
+In the case of CNAME records n a DNS response, a DoC server SHOULD follow common DNS resolver
+behavior {{?RFC1034}} by resolving a CNAME until the originally requested resource record type is
+reached. This reduces the number of message exchanges within an LLN.
 
 If not explicitly requested in the DNS query, it is RECOMMENDED to strip all record entries of type
 NS and class IN and all associated A and AAAA records from DNS responses received from upstream DNS

--- a/draft-lenders-dns-over-coap.md
+++ b/draft-lenders-dns-over-coap.md
@@ -273,7 +273,7 @@ reached. This reduces the number of message exchanges within an LLN.
 
 The DoC server SHOULD send compact answers, i.e., add additional or authority sections in the DNS
 reply should only be sent if needed or anticipated that they help the DoC client to reduce
-additional queries. Any additional information MAY be stripped from the DNS response.
+additional queries. Any excessive information MAY be stripped from the DNS response.
 
 Proxies and caching
 -------------------


### PR DESCRIPTION
Re-do of #14 

In our evaluation, we saw some larger response messages by cloud providers caused by NS record entries (even when those are not explicitly requested). We can't effectively use this with DoC anyway, so this adds a recommendation to strip them from a DNS response if not explicitly requested. Likewise, it adds a recommendation to resolve CNAMEs at the DoC server, to reduce DNS traffic within the LLN.